### PR TITLE
Replace the expired github domestic mirror for easy use

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ wget https://ghfast.top/https://raw.githubusercontent.com/stilleshan/frpc/master
 ```shell
 git clone https://github.com/stilleshan/frpc
 # git clone 本仓库镜像
-git clone https://ghp.ci/https://github.com/stilleshan/frpc
+git clone https://ghfast.top/https://github.com/stilleshan/frpc
 # 国内镜像
 vi /root/frpc/frpc.toml
 # 配置 frpc.toml 文件

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ```shell
 wget https://raw.githubusercontent.com/stilleshan/frpc/master/frpc_linux_install.sh && chmod +x frpc_linux_install.sh && ./frpc_linux_install.sh
 # 以下为国内镜像
-wget https://ghp.ci/https://raw.githubusercontent.com/stilleshan/frpc/master/frpc_linux_install.sh && chmod +x frpc_linux_install.sh && ./frpc_linux_install.sh
+wget https://ghfast.top/https://raw.githubusercontent.com/LoserLiunian/frpc/master/frpc_linux_install.sh && chmod +x frpc_linux_install.sh && ./frpc_linux_install.sh
 ```
 
 使用

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo systemctl restart frpc
 ```shell
 wget https://raw.githubusercontent.com/stilleshan/frpc/master/frpc_linux_uninstall.sh && chmod +x frpc_linux_uninstall.sh && ./frpc_linux_uninstall.sh
 # 以下为国内镜像
-wget https://ghp.ci/https://raw.githubusercontent.com/stilleshan/frpc/master/frpc_linux_uninstall.sh && chmod +x frpc_linux_uninstall.sh && ./frpc_linux_uninstall.sh
+wget https://ghfast.top/https://raw.githubusercontent.com/stilleshan/frpc/master/frpc_linux_uninstall.sh && chmod +x frpc_linux_uninstall.sh && ./frpc_linux_uninstall.sh
 ```
 
 ### 4. Linux 服务器 docker 安装

--- a/frpc_linux_install.sh
+++ b/frpc_linux_install.sh
@@ -16,7 +16,7 @@ WORK_PATH=$(dirname $(readlink -f $0))
 FRP_NAME=frpc
 FRP_VERSION=0.61.2
 FRP_PATH=/usr/local/frp
-PROXY_URL="https://ghp.ci/"
+PROXY_URL="https://ghfast.top/"
 
 # check frpc
 if [ -f "/usr/local/frp/${FRP_NAME}" ] || [ -f "/usr/local/frp/${FRP_NAME}.toml" ] || [ -f "/lib/systemd/system/${FRP_NAME}.service" ];then

--- a/frpc_synology_install.sh
+++ b/frpc_synology_install.sh
@@ -14,7 +14,7 @@ WORK_PATH=$(dirname $(readlink -f $0))
 FRP_NAME=frpc
 FRP_VERSION=0.62.0
 FRP_PATH=/usr/local/frp
-PROXY_URL="https://ghp.ci/"
+PROXY_URL="https://ghfast.top/"
 
 # check frpc
 if [ -f "/usr/local/frp/${FRP_NAME}" ] || [ -f "/usr/local/frp/${FRP_NAME}.toml" ] || [ -f "/lib/systemd/system/${FRP_NAME}.service" ];then


### PR DESCRIPTION
https://ghp.ci/ has been blocked in China and cannot be used
So replace it with https://ghfast.top/